### PR TITLE
opt: Deprecate Size method

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -60,7 +60,7 @@ func TestFind(t *testing.T) {
 	if i != 2 {
 		t.Errorf("expected 2, got %d", i)
 	}
-	i, ok = a.Iter().Find(func(i int) bool { return i == 4 })
+	_, ok = a.Iter().Find(func(i int) bool { return i == 4 })
 	if ok {
 		t.Errorf("expected false, got true")
 	}

--- a/linked_list.go
+++ b/linked_list.go
@@ -62,6 +62,11 @@ func (ll *DLList[T]) Iter() Iterator[T] {
 	}
 }
 
+// Len returns the number of elements in the list.
+func (ll *DLList[T]) Len() int {
+	return ll.size
+}
+
 // PopBack removes the last element from the list.
 // If the second return value is false, the list is empty and the zero value is returned.
 func (ll *DLList[T]) PopBack() (T, bool) {
@@ -140,6 +145,8 @@ func (ll *DLList[T]) ReverseIter() Iterator[T] {
 }
 
 // Size returns the number of elements in the list.
+//
+// Deprecated: Size is deprecated, use Len instead.
 func (ll *DLList[T]) Size() int {
 	return ll.size
 }

--- a/linked_list_test.go
+++ b/linked_list_test.go
@@ -147,13 +147,13 @@ func TestPushFront(t *testing.T) {
 	}
 }
 
-func TestSize(t *testing.T) {
+func TestLen(t *testing.T) {
 	var queue DLList[int]
 	queue.PushBack(1)
 	queue.PushBack(2)
 	queue.PushBack(3)
-	s := queue.Size()
+	s := queue.Len()
 	if s != 3 {
-		t.Errorf("queue.size = %d, want %d", s, 3)
+		t.Errorf("queue.len = %d, want %d", s, 3)
 	}
 }


### PR DESCRIPTION
For consistency with the other structs, the Size method is deprecated.
Instead, use Len method.